### PR TITLE
Fix missing dependency for flap_manipulation

### DIFF
--- a/aerial_motion/flap_manipulation/CMakeLists.txt
+++ b/aerial_motion/flap_manipulation/CMakeLists.txt
@@ -31,4 +31,3 @@ add_dependencies(flap_manipulation ${catkin_EXPORTED_TARGETS})
 
 add_executable(flap_manipulation_node src/flap_manipulation_node.cpp)
 target_link_libraries(flap_manipulation_node flap_manipulation ${catkin_LIBRARIES})
-target_link_libraries(flap_manipulation_node differential_kinematics_planner_core end_effector_ik_solver_core)

--- a/aerial_motion/flap_manipulation/CMakeLists.txt
+++ b/aerial_motion/flap_manipulation/CMakeLists.txt
@@ -6,10 +6,12 @@ add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
   squeeze_navigation
+  differential_kinematics
   )
 
 catkin_package(
   INCLUDE_DIRS include
+  CATKIN_DEPENDS squeeze_navigation differential_kinematics
   DEPENDS system_lib
 )
 
@@ -29,3 +31,4 @@ add_dependencies(flap_manipulation ${catkin_EXPORTED_TARGETS})
 
 add_executable(flap_manipulation_node src/flap_manipulation_node.cpp)
 target_link_libraries(flap_manipulation_node flap_manipulation ${catkin_LIBRARIES})
+target_link_libraries(flap_manipulation_node differential_kinematics_planner_core end_effector_ik_solver_core)

--- a/aerial_motion/flap_manipulation/package.xml
+++ b/aerial_motion/flap_manipulation/package.xml
@@ -12,5 +12,6 @@
   <depend>roscpp</depend>
   <depend>rospy</depend>
   <depend>squeeze_navigation</depend>
+  <depend>differential_kinematics</depend>
 
 </package>


### PR DESCRIPTION
## Summary
- fix build failure when linking flap_manipulation by adding missing dependency on `differential_kinematics`
- link flap_manipulation_node to the differential_kinematics libraries

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843e27674d8832dbd1b9aac5bbee5fa